### PR TITLE
protegiendo rutas de modificación

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -56,7 +56,6 @@ class UserController extends Controller
 
             if(Auth::attempt($credenciales)) {
                 $request->session()->regenerate();
-                $sessionid = $request->session()->getId();
 
                 $respuesta = new JsonResponse([
                     'loggedIn' => 1,

--- a/app/Http/Middleware/CheckActiveSession.php
+++ b/app/Http/Middleware/CheckActiveSession.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Exception;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+class CheckActiveSession
+{
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response | JsonResponse
+    {
+        try{
+            if(Auth::check()){
+                return $next($request);
+            }
+
+            return new JsonResponse([
+                'sessionActive' => 0,
+                'message' => 'Se ha intentado acceder con un usuario no autenticado'
+            ], 401);
+        }
+        catch(Exception $ex){
+            return new JsonResponse([
+                'sessionActive' => 0,
+                'message' => "Error interno del servidor {$ex->getMessage()}"
+            ], 500);
+        }
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,6 +3,7 @@
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Illuminate\Http\Middleware\HandleCors;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -13,6 +14,9 @@ return Application::configure(basePath: dirname(__DIR__))
     )
     ->withMiddleware(function (Middleware $middleware) {
         //
+        $middleware->api(append: [
+            HandleCors::class
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/config/cors.php
+++ b/config/cors.php
@@ -20,6 +20,8 @@ return [
     'allowed_methods' => ['*'],
 
     'allowed_origins' => ['https://www.policlinicolatrinidad.com'],
+    //'allowed_origins' => ['*'],
+    //'allowed_origins' => ['http://localhost:4321'],
 
     'allowed_origins_patterns' => [],
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -6,33 +6,46 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\PublicacionesController;
 use App\Http\Controllers\CarruselImagenesController;
 use App\Http\Controllers\UserController;
-use Illuminate\Http\Middleware\HandleCors;
+use App\Http\Middleware\CheckActiveSession;
 use Illuminate\Session\Middleware\StartSession;
 
 /*Route::get('/user', function (Request $request) {
     return $request->user();
 })->middleware('auth:sanctum');*/
 
+// El middleware HandleCors está actualmente colocado en bootstrap/app.php
+
+/**
+ * Rutas utilizadas para obtener datos de los fármacos
+ *
+ * TODO: Necesito comunicarme con el ingeniero de sistemas para saber como obtener
+ * datos de los fármacos
+ */
 Route::get('farmacos', [FarmacosController::class, 'index'])->name('farmacos.index');
 Route::get('farmacos/{id}', [FarmacosController::class, 'show'])->name('farmacos.show');
 
+// Rutas utilizadas para la administración de las imágenes en el carrusel
 Route::get('carruselimagenes', [CarruselImagenesController::class, 'index']);
 Route::get('carruselimagenes/{id}', [CarruselImagenesController::class, 'show']);
-Route::post('carruselimagenes', [CarruselImagenesController::class, 'store']);
-Route::put('carruselimagenesupdate/{id}', [CarruselImagenesController::class, 'update']);
-Route::delete('carruselimagenesdelete/{id}', [CarruselImagenesController::class, 'destroy']);
+Route::middleware([StartSession::class, CheckActiveSession::class])
+                ->post('carruselimagenes', [CarruselImagenesController::class, 'store']);
+Route::middleware([StartSession::class, CheckActiveSession::class])
+                ->put('carruselimagenesupdate/{id}', [CarruselImagenesController::class, 'update']);
+Route::middleware([StartSession::class, CheckActiveSession::class])
+                ->delete('carruselimagenesdelete/{id}', [CarruselImagenesController::class, 'destroy']);
 
+// Rutas utilizadas para la administración de publicaciones
 Route::get('publicaciones', [PublicacionesController::class, 'index']);
 Route::get('publicaciones/{id}', [PublicacionesController::class, 'show']);
-Route::post('publicaciones', [PublicacionesController::class, 'store']);
-Route::put('publicacionesupdate/{id}', [PublicacionesController::class, 'update']);
-Route::delete('publicacionesdelete/{id}', [PublicacionesController::class, 'destroy']);
+Route::middleware([StartSession::class, CheckActiveSession::class])
+                ->post('publicaciones', [PublicacionesController::class, 'store']);
+Route::middleware([StartSession::class, CheckActiveSession::class])
+                ->put('publicacionesupdate/{id}', [PublicacionesController::class, 'update']);
+Route::middleware([StartSession::class, CheckActiveSession::class])
+                ->delete('publicacionesdelete/{id}', [PublicacionesController::class, 'destroy']);
 
 // Para la autenticación en la página de publicaciones
-Route::middleware(StartSession::class)->post('auth-posts', [UserController::class, 'authenticate'])
-    ->middleware(HandleCors::class);
-Route::middleware(StartSession::class)->get('session-validation', [UserController::class, 'checkSession'])
-    ->middleware(HandleCors::class);
-Route::middleware(StartSession::class)->get('logout', [UserController::class, 'logout'])
-    ->middleware(HandleCors::class);
+Route::middleware(StartSession::class)->post('auth-posts', [UserController::class, 'authenticate']);
+Route::middleware(StartSession::class)->get('session-validation', [UserController::class, 'checkSession']);
+Route::middleware(StartSession::class)->get('logout', [UserController::class, 'logout']);
 Route::post('new-user', [UserController::class, 'create']);


### PR DESCRIPTION
Acabo de implementar las sesiones para las rutas de post, put y delete del carrusel y de las publicaciones, también implementé HandleCors para todas las rutas de la API, lo cual me permitió limitar el acceso a estas rutas a solo la página.

Falta incluir ```credentials: 'include'``` en todos los fetches que lean dichas rutas o si no las cookies de sesión no se enviarán (y te tratará como no autenticado).